### PR TITLE
Switch categories -> tags

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ name: openstack-api
 summary: Reative Layer - OpenStack API charms
 maintainer: OpenStack Charmers <openstack-charmers@lists.ubuntu.com>
 description: Layer for all OpenStack charms providing API services
-categories:
+tags:
   - openstack
 subordinate: false
 requires:


### PR DESCRIPTION
Charm proof will raise a warning on this:

W: Categories are being deprecated in favor of tags. Please rename the "categories" field to "tags".
